### PR TITLE
fixing typos in non-curried example

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,26 +123,26 @@ var requirements = [
   }
 ];
 
-validatePassword(requirements, 'password');
+mrCheckbox(requirements, 'password');
   =>  [
         'Password cannot be "password"',
         'Password must be a palindrome.';
       ]
 
 
-validatePassword(requirements, 'abc');
+mrCheckbox(requirements, 'abc');
   =>  [
         'Password must 8 characters or longer',
         'Password must be a palindrome.'
       ]
 
-validatePassword(requirements, 'QhannahhannahQ');
+mrCheckbox(requirements, 'QhannahhannahQ');
   =>  [ 'Password cannot start with the letter Q.' ]
 
-validatePassword(requirements, 'iiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii');
+mrCheckbox(requirements, 'iiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii');
   =>  [ 'Password must be 50 characters or shorter' ]
 
-validatePassword(requirements, 'hannahhannah');
+mrCheckbox(requirements, 'hannahhannah');
   => []
 
 ```


### PR DESCRIPTION
@ryanaghdam - I think this was just a copy-n-paste error from the first example, but in the non-curried example `validatePassword` isn't defined.
